### PR TITLE
Convert all string types to Cow<str>

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -19,6 +19,23 @@ pub struct Message<'a> {
 }
 
 impl<'a> Message<'a> {
+    pub fn into_owned(self) -> Message<'static> {
+        Message {
+            tags: BTreeMap::from_iter(
+                self.tags
+                    .into_iter()
+                    .map(|(k, v)| (Cow::Owned(k.into_owned()), Cow::Owned(v.into_owned()))),
+            ),
+            prefix: self.prefix.map(|s| Cow::Owned(s.into_owned())),
+            command: Cow::Owned(self.command.to_string()),
+            params: self
+                .params
+                .into_iter()
+                .map(|s| Cow::Owned(s.into_owned()))
+                .collect(),
+        }
+    }
+
     pub fn to_owned(&self) -> Message<'static> {
         Message {
             tags: BTreeMap::from_iter(

--- a/src/message.rs
+++ b/src/message.rs
@@ -19,19 +19,19 @@ pub struct Message<'a> {
 }
 
 impl<'a> Message<'a> {
-    pub fn to_owned(self) -> Message<'static> {
+    pub fn to_owned(&self) -> Message<'static> {
         Message {
             tags: BTreeMap::from_iter(
                 self.tags
-                    .into_iter()
-                    .map(|(k, v)| (Cow::Owned(k.into_owned()), Cow::Owned(v.into_owned()))),
+                    .iter()
+                    .map(|(k, v)| (Cow::Owned(k.to_string()), Cow::Owned(v.to_string()))),
             ),
-            prefix: self.prefix.map(|s| Cow::Owned(s.into_owned())),
-            command: Cow::Owned(self.command.into_owned()),
+            prefix: self.prefix.as_ref().map(|s| Cow::Owned(s.to_string())),
+            command: Cow::Owned(self.command.to_string()),
             params: self
                 .params
-                .into_iter()
-                .map(|s| Cow::Owned(s.into_owned()))
+                .iter()
+                .map(|s| Cow::Owned(s.to_string()))
                 .collect(),
         }
     }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -80,7 +80,7 @@ fn test_msg_split() {
             assert!(false, "Extra value {} for key {}", value, key);
         }
 
-        let prefix = test.atoms.source.as_deref();
+        let prefix = test.atoms.source.as_deref().map(Cow::Borrowed);
 
         assert_eq!(
             prefix, msg.prefix,
@@ -112,14 +112,19 @@ fn test_msg_join() {
         let mut tags = BTreeMap::new();
 
         for (k, v) in test.atoms.tags.iter() {
-            tags.insert(k.as_str(), Cow::Borrowed(v.as_str()));
+            tags.insert(Cow::Borrowed(k.as_str()), Cow::Borrowed(v.as_str()));
         }
 
         let msg = Message {
             tags,
-            prefix: test.atoms.source.as_deref(),
-            command: test.atoms.verb.as_str(),
-            params: test.atoms.params.iter().map(|s| s.as_str()).collect(),
+            prefix: test.atoms.source.as_deref().map(Cow::Borrowed),
+            command: Cow::Borrowed(test.atoms.verb.as_str()),
+            params: test
+                .atoms
+                .params
+                .iter()
+                .map(|s| Cow::Borrowed(s.as_str()))
+                .collect(),
         };
 
         let out = format!("{}", msg);


### PR DESCRIPTION
It looks like this is around 10% slower than the raw implementation, so I'm not sure if we want to do this or not.

```
% cargo bench
    Finished bench [optimized] target(s) in 0.02s
     Running target/release/deps/simple_irc-442faad8bd91eb30

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/release/deps/msg_split-55948918724ef525

running 2 tests
test parse_complex ... bench:         812 ns/iter (+/- 97)
test parse_simple  ... bench:         115 ns/iter (+/- 12)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured
```